### PR TITLE
Fix typos in documentation

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -6,7 +6,7 @@ layout: home
 nav_exclude: true
 has_toc: true
 ---
-![EEGLAb sum-up picture](/assets/images/tutorial_image.png)
+![EEGLAB sum-up picture](/assets/images/tutorial_image.png)
 <!-- <a href="https://eeglab.org/workshops/EEGLAB_2022_UCSD.html" style="color:red; font-size:30px">EEGLAB San Diego (Nov 2022) workshop registration open!</a>
 -->
 

--- a/others/TIPS_and_FAQ.md
+++ b/others/TIPS_and_FAQ.md
@@ -578,13 +578,13 @@ more complex to use. I guess it would also be possible to use the welch
 method on top of multitaper. It is all a matter of preference. I would
 advised using the pwelch method which is easy (you just give as an
 option the length of the windows and the overlap). Multitaper would
-require you to select the number of basis vector in your othogonal base
+require you to select the number of basis vector in your orthogonal base
 and this is much less intuitive (and also has consequences on the
 frequency resolution you can achieve).
 
-### Multitaper, FTT, wavelets for time-frequency decomposition?
+### Multitaper, FFT, wavelets for time-frequency decomposition?
 
-I have been using the new EELAB toolbox for the past
+I have been using the new EEGLAB toolbox for the past
 couple of weeks, especially timef() and crossf(). The multitaper method
 with bootstrap statistics has been giving me very nice stable results.
 Timef() with wavelets gives slightly different results, but also


### PR DESCRIPTION
## Summary
- correct minor typos in the FAQ
- fix EEGLAB alt text on the home page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686637b7307483228b203ea6f5806ecc