### PR TITLE
fix: restore search by keeping hidden search-button element in DOM

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -189,6 +189,12 @@ layout: table_wrappers
     </div>
 
     {% if site.search_enabled != false %}
+      {% if site.search.button %}
+        <a href="#" id="search-button" class="search-button" style="display:none;">
+          <svg viewBox="0 0 24 24" class="icon"><use xlink:href="#svg-search"></use></svg>
+        </a>
+      {% endif %}
+
       <div class="search-overlay"></div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary
- The `just-the-docs.js` `initNav()` function calls `jtd.addEvent` on the `#search-button` element unconditionally. When the element was removed in commit 9a6c338 (to avoid overlap with the OSA chat widget), `jtd.addEvent(null, ...)` threw an error, which prevented `initSearch()` from executing. The lunr search index was never built, leaving the header search input non-functional.
- Restores the `#search-button` element with `display:none` so the JS initializes without error while keeping the button invisible (no overlap with the chat widget).

## Test plan
- [x] Verified on live site by injecting hidden button element and re-loading JS; search results appeared correctly
- [ ] After deploy, confirm search field at top of page returns results when typing a query (e.g. "ICA")
- [ ] Confirm OSA chat widget in bottom-right does not overlap with anything